### PR TITLE
Simplifying travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ otp_release:
 sudo: false
 env:
   - MIX_ENV="test"
-script:
-  - mix test
 after_script:
   - mix deps.get --only docs
   - MIX_ENV=docs mix inch.report


### PR DESCRIPTION
Do not need the `mix test` if using default
